### PR TITLE
add rules for postgres and mssql datsources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ semodule -i grafana.pp
 semanage port -a -t grafana_port_t -p tcp 3000
 
 # Restore all the correct context labels
-restorecon -RvF /usr/sbin/grafana-* \
+restorecon -RvF /usr/sbin/grafana* \
 		/etc/grafana \
 		/var/log/grafana \
 		/var/lib/grafana \
@@ -85,7 +85,7 @@ sudo semodule -r grafana
 ```
 * Restore the contexts of the files
 ```sh
-restorecon -RvF /usr/sbin/grafana-* \
+restorecon -RvF /usr/sbin/grafana* \
 		/etc/grafana \
 		/var/log/grafana \
 		/var/lib/grafana \

--- a/grafana.fc
+++ b/grafana.fc
@@ -5,6 +5,7 @@
 
 /usr/sbin/grafana-cli					--	gen_context(system_u:object_r:grafana_exec_t,s0)
 /usr/sbin/grafana-server				--	gen_context(system_u:object_r:grafana_exec_t,s0)
+/usr/sbin/grafana				        --	gen_context(system_u:object_r:grafana_exec_t,s0)
 
 /var/lib/grafana(/.*)?						gen_context(system_u:object_r:grafana_var_lib_t,s0)
 #/var/lib/grafana/grafana.db				--	gen_context(system_u:object_r:grafana_db_t,s0)

--- a/grafana.te
+++ b/grafana.te
@@ -34,6 +34,12 @@ gen_tunable(grafana_can_tcp_connect_mysql_port, false)
 ## </desc>
 gen_tunable(grafana_can_tcp_connect_prometheus_port, false)
 
+## <desc>            
+## <p>
+## Allow grafana to connect to postgresql's default tcp port of 5432            
+## </p>            
+## </desc>            
+gen_tunable(grafana_can_tcp_connect_postgresql_port, false)
 
 type grafana_t;
 type grafana_exec_t;
@@ -74,6 +80,9 @@ can_exec(grafana_t, grafana_pcp_exec_t)
 # Ports 32768-60999 (pcp port is 44322)
 corenet_tcp_connect_all_ephemeral_ports(grafana_t)
 grafana_exec(grafana_t)
+
+# Allow grafana to connect to mssql's default tcp port of 1433 
+corenet_tcp_connect_mssql_port(grafana_t)
 
 ########################################
 #
@@ -181,6 +190,10 @@ tunable_policy(`grafana_can_tcp_connect_mysql_port',` # Mysql default tcp port 3
 
 tunable_policy(`grafana_can_tcp_connect_prometheus_port',` # Prometheus default tcp port 9090
 	corenet_tcp_connect_websm_port(grafana_t)
+')
+
+tunable_policy(`grafana_can_tcp_connect_postgresql_port',` # Postgresql default tcp port 5432
+	corenet_tcp_connect_postgresql_port(grafana_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
This change allows for connection to the default ports of the mssql and postgresql data sources. Additionally, this commit addresses changes to the grafana binaries.